### PR TITLE
Fix trimming

### DIFF
--- a/helm/cluster-openstack/templates/list.yaml
+++ b/helm/cluster-openstack/templates/list.yaml
@@ -4,9 +4,9 @@ items:
 - {{- include "cluster-class" . | indent 2 }}
 - {{- include "openstack-cluster-template" . | indent 2 }}
 - {{- include "kubeadm-control-plane-template" . | indent 2 }}
-{{- $outerScope := . -}}
+{{- $outerScope := . }}
 {{- range .Values.nodeClasses }}
-{{- $innerScope := merge $outerScope . -}}
+{{- $innerScope := merge $outerScope . }}
 - {{- include "kubeadm-config-template" $innerScope | indent 2 }}
 - {{- include "openstack-machine-template" $innerScope | indent 2 }}
 {{- end }}


### PR DESCRIPTION
Fixes (see trailing hyphen due to trimmed whitespace): 
```
        version: 1.20.9-  
  apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
  kind: KubeadmConfigTemplate
```
to
```
        version: 1.20.9
-  
  apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
  kind: KubeadmConfigTemplate
```