### PR TITLE
Add tags into OpenStackCluster objects

### DIFF
--- a/helm/cluster-openstack/templates/_openstack_cluster_template.tpl
+++ b/helm/cluster-openstack/templates/_openstack_cluster_template.tpl
@@ -9,6 +9,10 @@ metadata:
 spec:
   template:
     spec:
+      {{- if .Values.managementCluster }}
+      tags:
+      - giant_swarm_cluster_{{ .Values.managementCluster }}_{{ include "resource.default.name" $ }}
+      {{- end }}
       cloudName: {{ .Values.cloudName }}
       {{- if .Values.controlPlane.availabilityZones }}
       controlPlaneAvailabilityZones:

--- a/helm/cluster-openstack/values.yaml
+++ b/helm/cluster-openstack/values.yaml
@@ -3,6 +3,7 @@ organization: ""  # Organization in which to create the cluster.
 cloudConfig: cloud-config  # Name of cloud-config secret in destination namespace.
 cloudName: openstack  # Name of cloud in cloud-config secret "cloud.yaml" value.
 baseDomain: "example.com"
+managementCluster: ""
 
 kubernetesVersion: 1.20.9
 releaseVersion: 20.0.0-alpha1


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/710

To be able to track openstack resources created by CAPO for workload clusters, we need to pass cluster tags

```
cluster tag = giant_swarm_cluster_<management-cluster-name>_<worklaod-cluster-name>
```