### PR TITLE
Allow traffic between pod and host network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Allow traffic between pod and host network.
+
 ## [0.3.0] - 2022-01-26
 
 ### Added

--- a/helm/cluster-openstack/templates/_openstack_cluster_template.tpl
+++ b/helm/cluster-openstack/templates/_openstack_cluster_template.tpl
@@ -22,6 +22,7 @@ spec:
       externalNetworkId: {{ .Values.externalNetworkID }}
       {{- end }}
       {{- if .Values.dnsNameservers }}
+      allowAllInClusterTraffic: true
       dnsNameservers:
       {{- range .Values.dnsNameservers }}
       - {{ . }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/725

Needed to be able to scrape targets running in the host network.

Sibling change for the MC https://github.com/giantswarm/capo-mc-bootstrap/pull/58