### PR TITLE
Move machineInfrastructure from KubeadmControlPlaneTemplate to ClusterClass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Add empty value for `nodeCIDR` in `values.yaml`.
-- Move `machineInfrastructure` ref from `KubeadmControlPlaneTemplate` to `ClusterClass`
+- Move `machineInfrastructure` ref from `KubeadmControlPlaneTemplate` to `ClusterClass`.
 
 ## [0.2.2] - 2022-01-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Add empty value for `nodeCIDR` in `values.yaml`.
+- Move `machineInfrastructure` ref from `KubeadmControlPlaneTemplate` to `ClusterClass`
 
 ## [0.2.2] - 2022-01-24
 

--- a/helm/cluster-openstack/templates/_cluster_class.tpl
+++ b/helm/cluster-openstack/templates/_cluster_class.tpl
@@ -12,6 +12,11 @@ spec:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       kind: KubeadmControlPlaneTemplate
       name: {{ include "resource.default.name" $ }}
+    machineInfrastructure:
+      ref:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+        kind: OpenStackMachineTemplate
+        name: {{ include "resource.default.name" . }}-{{ .Values.controlPlane.class }}
   workers:
     machineDeployments:
     {{- range .Values.nodeClasses }}

--- a/helm/cluster-openstack/templates/_kubeadm_control_plane_template.tpl
+++ b/helm/cluster-openstack/templates/_kubeadm_control_plane_template.tpl
@@ -43,10 +43,4 @@ spec:
           {{- include "sshPostKubeadmCommands" . | nindent 10 }}
         users:
           {{- include "sshUsers" . | nindent 10 }}
-      machineTemplate:
-        infrastructureRef:
-          apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
-          kind: OpenStackMachineTemplate
-          name: {{ include "resource.default.name" . }}-{{ .Values.controlPlane.class }}
-      version: {{ .Values.kubernetesVersion }}
 {{- end -}}


### PR DESCRIPTION
`machineTemplate` in `KubeadmControlPlaneTemplate` is removed with CAPI v1.1.0
See https://github.com/kubernetes-sigs/cluster-api/pull/5788

We need to move that part to `clusterClass`.