### PR TITLE
Convert nodeCIDR to switch to use existing network+subnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add API server`certSANs` property to generate a certificate for the API FQDN.
-
+- Convert nodeCIDR to switch to use existing network+subnet.
+ 
 ### Changed
 
 - Restrict provider to `openstack`.

--- a/helm/cluster-openstack/templates/_openstack_cluster_template.tpl
+++ b/helm/cluster-openstack/templates/_openstack_cluster_template.tpl
@@ -27,6 +27,11 @@ spec:
       managedSecurityGroups: true
       {{- if .Values.nodeCIDR }}
       nodeCidr: {{ .Values.nodeCIDR }}
+      {{- else }}
+      network:
+        name: {{ .Values.networkName }}
+      subnet:
+        name: {{ .Values.subnetName }}
       {{- end }}
       {{- if .Values.externalNetworkID }}
       externalNetworkId: {{ .Values.externalNetworkID }}
@@ -43,6 +48,14 @@ spec:
         instance:
           flavor: {{ .Values.bastion.flavor }}
           image: {{ .Values.bastion.image }}
+          {{- if not .Values.nodeCIDR }}
+          networks:
+          - filter:
+              name: {{ .Values.networkName }}
+            subnets:
+            - filter:
+                name: {{ .Values.subnetName }} 
+          {{- end }}
           {{- if .Values.bastion.rootVolume.sourceUUID }}
           rootVolume:
             sourceType: image

--- a/helm/cluster-openstack/templates/_openstack_machine_template.tpl
+++ b/helm/cluster-openstack/templates/_openstack_machine_template.tpl
@@ -15,6 +15,14 @@ spec:
         name: {{ $.Values.cloudConfig }}
         kind: Secret
       image: "" # This is ignored when rootVolume.sourceUUID is specified.
+      {{- if not .Values.nodeCIDR }}
+      networks:
+      - filter:
+          name: {{ .Values.networkName }}
+        subnets:
+        - filter:
+            name: {{ .Values.subnetName }} 
+      {{- end }}
       {{- if $.Values.rootVolume.enabled }}
       rootVolume:
         sourceType: image

--- a/helm/cluster-openstack/values.yaml
+++ b/helm/cluster-openstack/values.yaml
@@ -8,8 +8,8 @@ managementCluster: ""
 kubernetesVersion: 1.20.9
 releaseVersion: 20.0.0-alpha1
 
-nodeCIDR: ""  # The OpenStack Subnet to be created.
-externalNetworkID: ""  # UUID of external network (optional).
+networkName: ""  # existing network name, used when nodeCIDR is empty
+subnetName: ""  # existing subnet name, used when nodeCIDR is empty
 
 oidc:
   enabled: false

--- a/helm/cluster-openstack/values.yaml
+++ b/helm/cluster-openstack/values.yaml
@@ -8,8 +8,10 @@ managementCluster: ""
 kubernetesVersion: 1.20.9
 releaseVersion: 20.0.0-alpha1
 
-networkName: ""  # existing network name, used when nodeCIDR is empty
-subnetName: ""  # existing subnet name, used when nodeCIDR is empty
+nodeCIDR: ""  # The OpenStack Subnet to be created.
+externalNetworkID: ""  # UUID of external network (optional).
+networkName: ""  # Existing network name. Ignored when nodeCIDR is set.
+subnetName: ""  # Existing subnet name. Ignored when nodeCIDR is set.
 
 oidc:
   enabled: false


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/773

CAPO uses nodeCIDR as a switch. When it is set, CAPO creates a network
and subnet. When it is not set, it uses an existing network and a subnet,
which must be declared by filters.

This PR reflects that mechanism to our helm chart.

See https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/73890460b8074ab55b3e3cb2545a2dd6f4a49739/controllers/openstackcluster_controller.go#L382