### PR TITLE
Move to cluster-catalog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,10 @@ workflows:
       - architect/push-to-app-catalog:
           context: "architect"
           executor: "app-build-suite"
-          name: "package and push cluster-openstack chart"
-          app_catalog: "giantswarm-catalog"
-          app_catalog_test: "giantswarm-test-catalog"
+          name: "push-to-app-catalog"
+          app_catalog: "cluster-catalog"
+          app_catalog_test: "cluster-test-catalog"
           chart: "cluster-openstack"
-          persist_chart_archive: true
           # Trigger job on git tag.
           filters:
             tags:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Move from `giantswarm-catalog` to `cluster-catalog`.
+
 ## [0.7.0] - 2022-03-04
 
 ### Added


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/21059

This PR:

- Moves the app from giantswarm-catalog to cluster-catalog.