### PR TITLE
Add MachineHealthCheck for all nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Move from `giantswarm-catalog` to `cluster-catalog`.
+- Add `MachineHealthCheck` for all nodes.
 
 ## [0.7.0] - 2022-03-04
 

--- a/helm/cluster-openstack/templates/_machine_health_check.tpl
+++ b/helm/cluster-openstack/templates/_machine_health_check.tpl
@@ -1,0 +1,23 @@
+{{- define "machine-health-check" }}
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: {{ include "resource.default.name" . }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  clusterName: {{ include "resource.default.name" $ }}
+  maxUnhealthy: 40%
+  nodeStartupTimeout: 20m0s
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: {{ include "resource.default.name" $ }}
+  unhealthyConditions:
+  - type: Ready
+    status: Unknown
+    timeout: 10m0s
+  - type: Ready
+    status: "False"
+    timeout: 10m0s
+{{- end -}}

--- a/helm/cluster-openstack/templates/list.yaml
+++ b/helm/cluster-openstack/templates/list.yaml
@@ -12,3 +12,4 @@ items:
 - {{- include "openstack-machine-template" $innerScope | indent 2 }}
 {{- end }}
 - {{- include "cluster" . | indent 2 }}
+- {{- include "machine-health-check" . | indent 2 }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/712

- This PR adds MHC for all nodes (infra + control plane nodes). When less than 40% of the nodes are not healthy, the unhealthy ones will be deleted&recreated. 

- When more than half of the control plane nodes are not healthy, KubeadmControlPlaneController gives this message: `"A control plane machine needs remediation, but removing this machine could result in etcd quorum loss. Skipping remediation"`.  

- We can define two separate MHC (one for CP, one for infra) but I don't see a huge benefit. 

<br>
**Example Scenarios (tested):**

- Setup: 1 Control Plane + 3 Infra
   Case: The control plane node is unhealthy
   Behavior: No remediation because of etcd quorum loss.
   
   
- Setup: 1 Control Plane + 3 Infra
   Case: One infra node is unhealthy
   Behavior: Infra node will be remediated

- Setup: 1 Control Plane + 3 Infra
   Case: 2 infra nodes are unhealthy
   Behavior:  No remediation because of  `maxUnhealthy` limit (50% > 40%)

- Setup: 3 Control Plane + 3 Infra
   Case: One control plane node is unhealthy
   Behavior: Control plane node will be remediated

- Setup: 3 Control Plane + 3 Infra
   Case: One control plane, one infra node are unhealthy
   Behavior: Both will be remediated (33% > 40%)

- Setup: 3 Control Plane + 3 Infra
   Case: Two infra nodes are unhealthy
   Behavior: Both will be remediated (33% > 40%)
  
- Setup: 3 Control Plane + 3 Infra
   Case: Two control plane nodes are unhealthy
   Behavior: No remediation because of etcd quorum loss.