### PR TITLE
Add cert SANs for 127.0.0.1 and localhost to api-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add cert SANs for 127.0.0.1 and localhost to api-server.
+
 ### Changed
 
 - Adapt control-plane configuration by comparing other providers and vintage clusters.

--- a/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
+++ b/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
@@ -10,6 +10,8 @@ spec:
     clusterConfiguration:
       apiServer:
         certSANs:
+          - 127.0.0.1
+          - localhost
           - "api.{{ include "resource.default.name" $ }}.{{ .Values.baseDomain }}"
         extraArgs:
           cloud-provider: external


### PR DESCRIPTION
This is to make it work with @fiunchinho PRs providing fixed to `initialBootstrapMode`:

- https://github.com/giantswarm/app-operator/pull/1018
- https://github.com/giantswarm/chart-operator/pull/903