### PR TITLE
Remove deprecated --insecure-port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove deprecated `--insecure-port` from api-server flags.
+
 ## [0.14.0] - 2022-07-19
 
 ### Added

--- a/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
+++ b/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
@@ -34,7 +34,6 @@ spec:
           enable-admission-plugins: {{ .Values.apiServer.enableAdmissionPlugins }}
           encryption-provider-config: /etc/kubernetes/encryption/config.yaml
           feature-gates: {{ .Values.apiServer.featureGates }}
-          insecure-port: "0"
           kubelet-preferred-address-types: "InternalIP"
           logtostderr: "true"
           {{- if .Values.oidc.issuerUrl }}


### PR DESCRIPTION
This flag was deprecated with 1.20 and it is removed with 1.24

https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#deprecation

### Testing

- [x] Fresh install works.
- [ ] Upgrade from previous version works.

### Checklist

- [x] Update changelog in `CHANGELOG.md`.
- [x] Make sure `values.yaml` is valid.
