### PR TITLE
[THG #134] Allow oidc-username-prefix to be configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow setting `--oidc-username-prefix` in api-server flags.
+
 ## [0.14.1] - 2022-07-19
 
 ### Changed
 
 - Remove deprecated `--insecure-port` from api-server flags.
-
-### Added
-
-- Allow setting `--oidc-username-prefix` in api-server flags.
 
 ## [0.14.0] - 2022-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove deprecated `--insecure-port` from api-server flags.
 
+### Added
+
+- Allow setting `--oidc-username-prefix` in api-server flags.
+
 ## [0.14.0] - 2022-07-19
 
 ### Added

--- a/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
+++ b/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
@@ -44,6 +44,7 @@ spec:
           oidc-groups-claim: {{ .groupsClaim }}
           {{- if .usernamePrefix }}
           oidc-username-prefix: {{ .usernamePrefix }}
+          {{- end }}
           {{- if .caFile }}
           oidc-ca-file: {{ .caFile }}
           {{- end }}

--- a/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
+++ b/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
@@ -42,7 +42,7 @@ spec:
           oidc-client-id: {{ .clientId }}
           oidc-username-claim: {{ .usernameClaim }}
           oidc-groups-claim: {{ .groupsClaim }}
-          {{- if .usernamePrefix}}
+          {{- if .usernamePrefix }}
           oidc-username-prefix: {{ .usernamePrefix }}
           {{- if .caFile }}
           oidc-ca-file: {{ .caFile }}

--- a/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
+++ b/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
@@ -42,6 +42,8 @@ spec:
           oidc-client-id: {{ .clientId }}
           oidc-username-claim: {{ .usernameClaim }}
           oidc-groups-claim: {{ .groupsClaim }}
+          {{- if .usernamePrefix}}
+          oidc-username-prefix: {{ .usernamePrefix }}
           {{- if .caFile }}
           oidc-ca-file: {{ .caFile }}
           {{- end }}

--- a/helm/cluster-openstack/values.schema.json
+++ b/helm/cluster-openstack/values.schema.json
@@ -193,6 +193,9 @@
                 },
                 "usernameClaim": {
                     "type": "string"
+                },
+                "usernamePrefix": {
+                    "type": "string"
                 }
             },
             "required": [

--- a/helm/cluster-openstack/values.yaml
+++ b/helm/cluster-openstack/values.yaml
@@ -24,6 +24,7 @@ oidc:
   clientId: ""
   usernameClaim: ""
   groupsClaim: ""
+  usernamePrefix: ""
 
 ignition:
   enable: false


### PR DESCRIPTION
This PR:

- Allows users to configure the value for `usernamePrefix` as part of the OIDC configuration as requested in [this issue](https://github.com/giantswarm/thg/issues/134).

### Testing

- [x] Fresh install works.
- [x] Upgrade from previous version works.

### Checklist

- [x] Update changelog in `CHANGELOG.md`.
- [x] Make sure `values.yaml` is valid.
