### PR TITLE
Add missing quotes for --oidc-username-prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add quotes for `--oidc-username-prefix` flag.
+
 ## [0.15.0] - 2022-08-16
 
 ### Added

--- a/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
+++ b/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
@@ -43,7 +43,7 @@ spec:
           oidc-username-claim: {{ .usernameClaim }}
           oidc-groups-claim: {{ .groupsClaim }}
           {{- if .usernamePrefix }}
-          oidc-username-prefix: {{ .usernamePrefix }}
+          oidc-username-prefix: {{ .usernamePrefix | quote }}
           {{- end }}
           {{- if .caFile }}
           oidc-ca-file: {{ .caFile }}


### PR DESCRIPTION
When we use `oidc:` as `usernamePrefix`, we hit this error

```
    reason: 'Deployment failed for `0.15.0` with `unknown-error`: `YAML parse error
      on cluster-openstack/templates/kubeadm_control_plane.yaml: error converting
      YAML to JSON: yaml: line 34: mapping values are not allowed in this context`'
```

We need to add quotes. Tested&Verified.

### Testing

- [x] Fresh install works.
- [x] Upgrade from previous version works.

### Checklist

- [x] Update changelog in `CHANGELOG.md`.
- [x] Make sure `values.yaml` is valid.
