### PR TITLE
Move specs of immutable templates to helpers.tpl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Move specs of immutable templates to helpers.tpl to make maintenance easier.
+
 ## [0.15.2] - 2022-08-17
 
 ### Fixed

--- a/helm/cluster-openstack/templates/kubeadm_config_template.yaml
+++ b/helm/cluster-openstack/templates/kubeadm_config_template.yaml
@@ -5,39 +5,10 @@ kind: KubeadmConfigTemplate
 metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
-  name: {{ include "resource.default.name" . }}-{{ .name }}-{{- include "kubeAdmConfigTemplateRevision" $ }}
+  name: {{ include "resource.default.name" . }}-{{ .name }}-{{- include "kubeAdmConfigTemplateRevision" (merge (dict "pool" .) $) }}
   namespace: {{ $.Release.Namespace }}
 spec:
   template:
     spec:
-      {{- if .Values.ignition.enable }}
-      format: ignition
-      ignition:
-        containerLinuxConfig:
-          additionalConfig: |
-            systemd:
-              units:
-              - name: kubeadm.service
-                enabled: true
-                dropins:
-                - name: 10-flatcar.conf
-                  contents: |
-                    [Unit]
-                    Requires=containerd.service
-                    After=containerd.service
-      {{- end }}
-      joinConfiguration:
-        nodeRegistration:
-          kubeletExtraArgs:
-            {{- include "kubeletExtraArgs" . | nindent  12}}
-            node-labels: "giantswarm.io/node-pool={{ .name }}"
-          name: {{ include "nodeName" . }}
-      files:
-        {{- include "sshFiles" . | nindent 8 }}
-      preKubeadmCommands:
-        {{- include "nodeNameReplacePreKubeadmCommands" . | nindent 8 }}
-      postKubeadmCommands:
-        {{- include "sshPostKubeadmCommands" . | nindent 8 }}
-      users:
-        {{- include "sshUsers" . | nindent 8 }}
+      {{- include "kubeAdmConfigTemplateSpec" (merge (dict "pool" .) $) | nindent 6 -}}
 {{- end }}

--- a/helm/cluster-openstack/templates/machine_deployment.yaml
+++ b/helm/cluster-openstack/templates/machine_deployment.yaml
@@ -22,7 +22,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: {{ include "resource.default.name" $ }}-{{ .name }}-{{- include "kubeAdmConfigTemplateRevision" $ }}
+          name: {{ include "resource.default.name" $ }}-{{ .name }}-{{- include "kubeAdmConfigTemplateRevision" (merge (dict "pool" .) $) }}
       clusterName: {{ include "resource.default.name" $ }}
       failureDomain: {{ .failureDomain | quote }}
       infrastructureRef:

--- a/helm/cluster-openstack/templates/openstack_machine_template.yaml
+++ b/helm/cluster-openstack/templates/openstack_machine_template.yaml
@@ -10,22 +10,5 @@ metadata:
 spec:
   template:
     spec:
-      cloudName: {{ $.Values.cloudName | quote }}
-      flavor: {{ .flavor | quote }}
-      identityRef:
-        name: {{ $.Values.cloudConfig }}
-        kind: Secret
-      {{- if not $.Values.nodeCIDR }}
-      networks:
-      - filter:
-          name: {{ $.Values.networkName }}
-        subnets:
-        - filter:
-            name: {{ $.Values.subnetName }}
-      {{- end }}
-      {{- if .bootFromVolume }}
-      rootVolume:
-        diskSize: {{ .diskSize }}
-      {{- end }}
-      image: {{ .image | quote }}
+      {{- include "osmtSpec" (merge . $) | nindent 6 -}}
 {{- end }}

--- a/helm/cluster-openstack/values.schema.json
+++ b/helm/cluster-openstack/values.schema.json
@@ -235,7 +235,6 @@
         "controlPlane",
         "kubernetesVersion",
         "managementCluster",
-        "nodeCIDR",
         "nodeClasses",
         "nodePools",
         "organization"

--- a/helm/cluster-openstack/values.schema.json
+++ b/helm/cluster-openstack/values.schema.json
@@ -235,6 +235,7 @@
         "controlPlane",
         "kubernetesVersion",
         "managementCluster",
+        "nodeCIDR",
         "nodeClasses",
         "nodePools",
         "organization"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/23340

When we change something in the templates without changing existing parameters, it doesn't trigger an update since the functions that compute revision suffix give the same result. `salt` is a workaround to be able to trigger updates. 

### Testing

- [x] Fresh install works.
- [x] Upgrade from previous version works.

### Checklist

- [x] Update changelog in `CHANGELOG.md`.
- [x] Make sure `values.yaml` is valid.
