### PR TITLE
enable kubeadm patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Move specs of immutable templates to helpers.tpl to make maintenance easier.
 
+### Added
+
+- Allow core-component configuration via `kubeadm --patches`
+
 ## [0.15.2] - 2022-08-17
 
 ### Fixed

--- a/helm/cluster-openstack/files/etc/patches/kube-apiserver+json.json
+++ b/helm/cluster-openstack/files/etc/patches/kube-apiserver+json.json
@@ -1,0 +1,7 @@
+[
+    {
+        "op": "add",
+        "path": "/spec/dnsPolicy",
+        "value": "ClusterFirstWithHostNet"
+    }
+]

--- a/helm/cluster-openstack/templates/_helpers.tpl
+++ b/helm/cluster-openstack/templates/_helpers.tpl
@@ -111,7 +111,7 @@ It is necessary to create a new template with a new name to trigger an upgrade.
 See https://github.com/kubernetes-sigs/cluster-api/issues/4910
 See https://github.com/kubernetes-sigs/cluster-api/pull/5027/files
 */}}
-{{- define "kubeAdmConfigTemplateSpec" -}}
+{{- define "kubeadmConfigTemplateSpec" -}}
 {{- if .Values.ignition.enable -}}
 format: ignition
 ignition:
@@ -144,9 +144,9 @@ users:
   {{- include "sshUsers" . | nindent 2 }}
 {{- end -}}
 
-{{- define "kubeAdmConfigTemplateRevision" -}}
+{{- define "kubeadmConfigTemplateRevision" -}}
 {{- $inputs := (dict
-  "data" (include "kubeAdmConfigTemplateSpec" .) ) }}
+  "data" (include "kubeadmConfigTemplateSpec" .) ) }}
 {{- mustToJson $inputs | toString | quote | sha1sum | trunc 8 }}
 {{- end -}}
 

--- a/helm/cluster-openstack/templates/kubeadm_config_template.yaml
+++ b/helm/cluster-openstack/templates/kubeadm_config_template.yaml
@@ -5,10 +5,10 @@ kind: KubeadmConfigTemplate
 metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
-  name: {{ include "resource.default.name" . }}-{{ .name }}-{{- include "kubeAdmConfigTemplateRevision" (merge (dict "pool" .) $) }}
+  name: {{ include "resource.default.name" . }}-{{ .name }}-{{- include "kubeadmConfigTemplateRevision" (merge (dict "pool" .) $) }}
   namespace: {{ $.Release.Namespace }}
 spec:
   template:
     spec:
-      {{- include "kubeAdmConfigTemplateSpec" (merge (dict "pool" .) $) | nindent 6 -}}
+      {{- include "kubeadmConfigTemplateSpec" (merge (dict "pool" .) $) | nindent 6 -}}
 {{- end }}

--- a/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
+++ b/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
@@ -79,11 +79,15 @@ spec:
           authorization-always-allow-paths: "/healthz,/readyz,/livez,/metrics"
           bind-address: "0.0.0.0"
     initConfiguration:
+      patches:
+        directory: "/tmp/kubeadm/patches"
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
         name: {{ include "nodeName" . }}
     joinConfiguration:
+      patches:
+        directory: "/tmp/kubeadm/patches"
       nodeRegistration:
         kubeletExtraArgs:
           {{- include "kubeletExtraArgs" . | nindent  10}}
@@ -100,6 +104,11 @@ spec:
           secret:
             name: {{ include "resource.default.name" $ }}-encryption-provider-config
             key: encryption
+      {{- range $kubeadmPatch, $_ :=  .Files.Glob  "files/etc/patches/**" }}
+      - path: {{ (printf "/tmp/kubeadm/patches/%s" (base $kubeadmPatch)) }}
+        content: |-
+          {{- $.Files.Get $kubeadmPatch | nindent 10 }}
+      {{- end }}
     preKubeadmCommands:
       {{- include "nodeNameReplacePreKubeadmCommands" . | nindent 6 }}
       {{- include "kubeProxyPreKubeadmCommands" . | nindent 6 }}

--- a/helm/cluster-openstack/templates/machine_deployment.yaml
+++ b/helm/cluster-openstack/templates/machine_deployment.yaml
@@ -22,7 +22,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: {{ include "resource.default.name" $ }}-{{ .name }}-{{- include "kubeAdmConfigTemplateRevision" (merge (dict "pool" .) $) }}
+          name: {{ include "resource.default.name" $ }}-{{ .name }}-{{- include "kubeadmConfigTemplateRevision" (merge (dict "pool" .) $) }}
       clusterName: {{ include "resource.default.name" $ }}
       failureDomain: {{ .failureDomain | quote }}
       infrastructureRef:


### PR DESCRIPTION
* enable kubeadm patches to configure core components

Signed-off-by: Mario Constanti <mario@constanti.de>

This PR:

- Adds json-patch support for control plane compoments
- Changes the `dnsPolicy` to `ClusterFirstWithHostNet` for the k8s APIserver
- requires an updated CAPI version (`v1.2.x`) - current used version at giantswarm (`v1.1.2`)

### Testing

- [ ] Fresh install works.
- [ ] Upgrade from previous version works.

### Checklist

- [x] Update changelog in `CHANGELOG.md`.
- [x] Make sure `values.yaml` is valid.
