### PR TITLE
Configure API Priority and Fairness based on node resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improve the README in the project.
+- Configure API priority and fairness flags based on node resources.
 
 ## [0.16.1] - 2022-09-22
 

--- a/helm/cluster-openstack/files/etc/patches/kube-apiserver+json.json
+++ b/helm/cluster-openstack/files/etc/patches/kube-apiserver+json.json
@@ -1,7 +1,0 @@
-[
-    {
-        "op": "add",
-        "path": "/spec/dnsPolicy",
-        "value": "ClusterFirstWithHostNet"
-    }
-]

--- a/helm/cluster-openstack/files/etc/patches/kube-apiserver+json.tpl
+++ b/helm/cluster-openstack/files/etc/patches/kube-apiserver+json.tpl
@@ -1,0 +1,27 @@
+[
+    {
+        "op": "add",
+        "path": "/spec/dnsPolicy",
+        "value": "ClusterFirstWithHostNet"
+    },
+    {
+        "op": "add",
+        "path": "/spec/containers/0/command/-",
+        "value": "--max-requests-inflight=$MAX_REQUESTS_INFLIGHT"
+    },
+    {
+        "op": "add",
+        "path": "/spec/containers/0/command/-",
+        "value": "--max-mutating-requests-inflight=$MAX_MUTATING_REQUESTS_INFLIGHT"
+    },
+    {
+        "op": "replace",
+        "path": "/spec/containers/0/resources/requests/cpu",
+        "value": "$API_SERVER_CPU_REQUEST"
+    },
+    {
+        "op": "replace",
+        "path": "/spec/containers/0/resources/requests/memory",
+        "value": "$API_SERVER_MEMORY_REQUEST"
+    }
+]

--- a/helm/cluster-openstack/files/etc/patches/kube-apiserver-patch.sh
+++ b/helm/cluster-openstack/files/etc/patches/kube-apiserver-patch.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+#
+# Creates kube-apiserver+json.json file by replacing
+# environment variables in kube-apiserver+json.tpl
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+cpus="$(grep -c ^processor /proc/cpuinfo)"
+memory="$(awk '/MemTotal/ { printf "%d \n", $2/1024 }' /proc/meminfo)"
+
+export MAX_REQUESTS_INFLIGHT=$((cpus*200))
+export MAX_MUTATING_REQUESTS_INFLIGHT=$((cpus*100))
+export API_SERVER_CPU_REQUEST=$((cpus*125))m
+export API_SERVER_MEMORY_REQUEST=$((memory / 8))Mi
+
+envsubst < "/tmp/kubeadm/patches/kube-apiserver+json.tpl"  > "/tmp/kubeadm/patches/kube-apiserver+json.json"

--- a/helm/cluster-openstack/files/etc/patches/kube-apiserver-patch.sh
+++ b/helm/cluster-openstack/files/etc/patches/kube-apiserver-patch.sh
@@ -8,13 +8,22 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+set -x
+
+if [ "$#" -ne 1 ]; then
+    echo "Illegal number of parameters" >&2
+    echo "Usage: bash kube-apiserver-patch.sh <resource-ratio>" >&2
+    exit 1
+fi
+
+ratio=$1
 
 cpus="$(grep -c ^processor /proc/cpuinfo)"
 memory="$(awk '/MemTotal/ { printf "%d \n", $2/1024 }' /proc/meminfo)"
 
-export MAX_REQUESTS_INFLIGHT=$((cpus*200))
-export MAX_MUTATING_REQUESTS_INFLIGHT=$((cpus*100))
-export API_SERVER_CPU_REQUEST=$((cpus*125))m
-export API_SERVER_MEMORY_REQUEST=$((memory / 8))Mi
+export MAX_REQUESTS_INFLIGHT=$((cpus*(1600/ratio)))
+export MAX_MUTATING_REQUESTS_INFLIGHT=$((cpus*(800/ratio)))
+export API_SERVER_CPU_REQUEST=$((cpus*(1000/ratio)))m
+export API_SERVER_MEMORY_REQUEST=$((memory/ratio))Mi
 
 envsubst < "/tmp/kubeadm/patches/kube-apiserver+json.tpl"  > "/tmp/kubeadm/patches/kube-apiserver+json.json"

--- a/helm/cluster-openstack/templates/_helpers.tpl
+++ b/helm/cluster-openstack/templates/_helpers.tpl
@@ -89,6 +89,10 @@ room for such suffix.
 - bash /etc/gs-kube-proxy-patch.sh
 {{- end -}}
 
+{{- define "apiServerPreKubeadmCommands" -}}
+- bash /tmp/kubeadm/patches/kube-apiserver-patch.sh
+{{- end -}}
+
 {{- define "nodeName" -}}
 {{- if .Values.ignition.enable -}}
 __REPLACE_NODE_NAME__

--- a/helm/cluster-openstack/templates/_helpers.tpl
+++ b/helm/cluster-openstack/templates/_helpers.tpl
@@ -89,10 +89,6 @@ room for such suffix.
 - bash /etc/gs-kube-proxy-patch.sh
 {{- end -}}
 
-{{- define "apiServerPreKubeadmCommands" -}}
-- bash /tmp/kubeadm/patches/kube-apiserver-patch.sh
-{{- end -}}
-
 {{- define "nodeName" -}}
 {{- if .Values.ignition.enable -}}
 __REPLACE_NODE_NAME__

--- a/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
+++ b/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
@@ -110,9 +110,9 @@ spec:
           {{- $.Files.Get $kubeadmPatch | nindent 10 }}
       {{- end }}
     preKubeadmCommands:
+      - bash /tmp/kubeadm/patches/kube-apiserver-patch.sh {{ .Values.controlPlane.resourceRatio }}
       {{- include "nodeNameReplacePreKubeadmCommands" . | nindent 6 }}
       {{- include "kubeProxyPreKubeadmCommands" . | nindent 6 }}
-      {{- include "apiServerPreKubeadmCommands" . | nindent 6 }}
     postKubeadmCommands:
       {{- include "sshPostKubeadmCommands" . | nindent 6 }}
     users:

--- a/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
+++ b/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
@@ -112,6 +112,7 @@ spec:
     preKubeadmCommands:
       {{- include "nodeNameReplacePreKubeadmCommands" . | nindent 6 }}
       {{- include "kubeProxyPreKubeadmCommands" . | nindent 6 }}
+      {{- include "apiServerPreKubeadmCommands" . | nindent 6 }}
     postKubeadmCommands:
       {{- include "sshPostKubeadmCommands" . | nindent 6 }}
     users:

--- a/helm/cluster-openstack/values.schema.json
+++ b/helm/cluster-openstack/values.schema.json
@@ -100,11 +100,16 @@
                     "minimum": 1,
                     "maximum": 7,
                     "type": "integer"
+                },
+                "resourceRatio" : {
+                    "minimum": 2,
+                    "type": "integer"
                 }
             },
             "required": [
                 "flavor",
-                "image"
+                "image",
+                "resourceRatio"
             ]
         },
         "dnsNameservers": {

--- a/helm/cluster-openstack/values.yaml
+++ b/helm/cluster-openstack/values.yaml
@@ -45,6 +45,7 @@ controlPlane:
   etcd:
     imageRepository: "giantswarm"
     imageTag: 3.5.4-0-k8s
+  resourceRatio: 8  # Ratio between node resources and apiserver resource requests.
 
 nodeClasses: []  # Class definitions for worker node pools. In addition to a required "name", may include "diskSize", "flavor", "image", and "bootFromVolume" as defined for control plane and bastion above.
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/23940

After checking all possible scenarios, I think there is no single ratio that fits all cases. The default ratio is `1/8` by default now. We can increase it for highly loaded MC clusters. 

### Testing

- [x] Fresh install works.
- [x] Upgrade from previous version works.

### Checklist

- [x] Update changelog in `CHANGELOG.md`.
- [x] Make sure `values.yaml` is valid.
