### PR TITLE
remove kube-dns svc recreation

### DIFF
--- a/helm/cluster-openstack/Chart.lock
+++ b/helm/cluster-openstack/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: cluster-shared
   repository: https://giantswarm.github.io/cluster-catalog
-  version: 0.6.2
-digest: sha256:4a769e78f73bffc6d7074820beeb665720f8cb44718a1afa2889c8fc39861436
-generated: "2022-09-22T14:46:36.377426178+02:00"
+  version: 0.6.3
+digest: sha256:ab31324bbea786b53436e44c63bbb58c2a146b3ea461a992ed81283156b5bc34
+generated: "2022-10-27T14:22:22.781513579+02:00"

--- a/helm/cluster-openstack/Chart.yaml
+++ b/helm/cluster-openstack/Chart.yaml
@@ -12,5 +12,5 @@ restrictions:
 icon: https://s.giantswarm.io/app-icons/openstack/1/light.svg
 dependencies:
   - name: cluster-shared
-    version: "0.6.2"
+    version: "0.6.3"
     repository: "https://giantswarm.github.io/cluster-catalog"


### PR DESCRIPTION
the recreation of kube-dns svc during the coredns app adoption was only required to not brake existing clusters.

This PR:

- Adds/changes/removes...

### Testing

- [ ] Fresh install works.
- [ ] Upgrade from previous version works.

### Checklist

- [X] Update changelog in `CHANGELOG.md`.
- [ ] Make sure `values.yaml` is valid.
