### PR TITLE
Add conversion table for every Kubernetes version and machine image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add matrix with Kubernetes version per machine image.
+
 ## [0.17.0] - 2022-11-07
 
 ### Changed

--- a/helm/cluster-openstack/ci/ci-values.yaml
+++ b/helm/cluster-openstack/ci/ci-values.yaml
@@ -7,7 +7,12 @@ dnsNameservers:
 - 1.1.1.1
 - 8.8.8.8
 externalNetworkID: external-network-id
-kubernetesVersion: 1.20.9
+kubernetesVersion: v1.22.9
+kubernetesVersionImages:
+  v1.22.9: "ubuntu-2004-kube-v1.22.9"
+  v1.23.14: "ubuntu-2004-kube-v1.23.14"
+  v1.24.8: "ubuntu-2004-kube-v1.24.8"
+  v1.25.4: "ubuntu-2004-kube-v1.25.4"
 managementCluster: testmc
 nodeCIDR: 10.6.0.0/24
 organization: testorg
@@ -18,7 +23,6 @@ oidc:
 bastion:
   diskSize: 10
   flavor: bastion-flavor
-  image: bastion-image
   bootFromVolume: true
 
 controlPlane:
@@ -28,14 +32,12 @@ controlPlane:
   - az3
   diskSize: 20
   flavor: control-plane-flavor
-  image: control-plane-image
   replicas: 3
   bootFromVolume: true
 
 nodeClasses:
   default:
     diskSize: 30
-    image: worker-image
     flavor: worker-flavor
     bootFromVolume: true
 

--- a/helm/cluster-openstack/templates/_helpers.tpl
+++ b/helm/cluster-openstack/templates/_helpers.tpl
@@ -49,6 +49,15 @@ room for such suffix.
 {{ .Values.clusterName }}
 {{- end -}}
 
+
+{{/*
+Return the image for a specific Kubernetes version.
+The matrix is defined in Values yaml and here we parsed it and pass the corresponding image.
+*/}}
+{{- define "imageName" -}}
+{{ get .Values.kubernetesVersionImages .Values.kubernetesVersion }}
+{{- end -}}
+
 {{- define "sshFiles" -}}
 - path: /etc/ssh/trusted-user-ca-keys.pem
   permissions: "0600"
@@ -173,7 +182,7 @@ networks:
 rootVolume:
   diskSize: {{ .currentClass.diskSize }}
 {{- end }}
-image: {{ .currentClass.image | quote }}
+image: {{ include "imageName" (dict "Values" $) }}
 {{- end -}}
 
 {{- define "osmtRevision" -}}

--- a/helm/cluster-openstack/templates/openstack_cluster.yaml
+++ b/helm/cluster-openstack/templates/openstack_cluster.yaml
@@ -57,4 +57,4 @@ spec:
       rootVolume:
         diskSize: {{ .Values.bastion.diskSize }}
       {{- end }}
-      image: {{ .Values.bastion.image | quote }}
+      image: {{ include "imageName" . }}

--- a/helm/cluster-openstack/values.schema.json
+++ b/helm/cluster-openstack/values.schema.json
@@ -38,8 +38,7 @@
                 }
             },
             "required": [
-                "flavor",
-                "image"
+                "flavor"
             ]
         },
         "cloudConfig": {
@@ -108,7 +107,6 @@
             },
             "required": [
                 "flavor",
-                "image",
                 "resourceRatio"
             ]
         },

--- a/helm/cluster-openstack/values.schema.json
+++ b/helm/cluster-openstack/values.schema.json
@@ -141,6 +141,9 @@
         "kubernetesVersion": {
             "type": "string"
         },
+        "kubernetesVersionImages": {
+            "type": "object"
+        },
         "managementCluster": {
             "type": "string"
         },

--- a/helm/cluster-openstack/values.yaml
+++ b/helm/cluster-openstack/values.yaml
@@ -9,7 +9,13 @@ clusterName: ""  # Name of cluster. Used as base name for all cluster resources 
 controllerManager:
   featureGates: "ExpandPersistentVolumes=true,TTLAfterFinished=true"
 dnsNameservers: []  # IPs of DNS nameservers to be used by the cluster machines (optional, will use OS defaults if not specified).
-kubernetesVersion: ""  # Version of Kubernetes. If machine images are specified, this will only be used for metadata.
+kubernetesVersion: "v1.22.9"  # Default Kubernetes version. If machine images are specified, this will only be used for metadata.
+kubernetesVersionImages:
+  v1.22.9: "ubuntu-2004-kube-v1.22.9"
+  v1.23.14: "ubuntu-2004-kube-v1.23.14"
+  v1.24.8: "ubuntu-2004-kube-v1.24.8"
+  v1.25.4: "ubuntu-2004-kube-v1.25.4"
+
 managementCluster: ""  # Name of cluster which owns this workload cluster.
 organization: ""  # Organization which owns the cluster.
 
@@ -30,16 +36,14 @@ ignition:
   enable: false
 
 bastion:
-  diskSize: 0  # Root volume disk size in GB. Ignored if bootFromVolume is false. Should be at least as large as the source image.
+  diskSize: 0  # Root volume disk size in GB. Ignored if bootFromVolume is false.
   flavor: ""  # Project-dependent flavor of bastion machine.
-  image: ""  # Image name or root volume source UUID if bootFromVolume is true.
   bootFromVolume: false  # If true, machines will use a persistent root volume instead of an ephemeral volume.
 
 controlPlane:
   availabilityZones: []  # Unique availability zones for control plane nodes. If specified, should have one item or one for each replica (optional).
   diskSize: 0  # Root volume disk size in GB. Ignored if bootFromVolume is false. Should be at least as large as the source image.
   flavor: ""  # Project-dependent flavor of control plane machines.
-  image: ""  # Image name or root volume source UUID if bootFromVolume is true.
   replicas: 0  # Number of replicas in control plane. Should be an odd number.
   bootFromVolume: false  # If true, machines will use a persistent root volume instead of an ephemeral volume.
   etcd:
@@ -47,12 +51,11 @@ controlPlane:
     imageTag: 3.5.4-0-k8s
   resourceRatio: 8  # Ratio between node resources and apiserver resource requests.
 
-nodeClasses: {}  # Class definitions for worker node pools. The "name" of the class is the key of the object. The properties may include "diskSize", "flavor", "image", and "bootFromVolume" as defined for control plane and bastion above. Example:
+nodeClasses: {}  # Class definitions for worker node pools. The "name" of the class is the key of the object. The properties may include "diskSize", "flavor", and "bootFromVolume" as defined for control plane and bastion above. Example:
   # default:
   #   bootFromVolume: true
   #   diskSize: 50
   #   flavor: n1.medium
-  #   image: ubuntu-2004-kube-v1.22.9
 
 nodePools: {}  # Node pools that should exist for the cluster. Each node pool must refer to a class defined in nodeClasses above. Example:
   # us-dc-1:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/23341

This PR:

- Adds matrix with Kubernetes Version and machine image so customers can rely on defaults and we only need to define target k8s version

### Testing

- [x] Fresh install works.
- [x] Upgrade from previous version works.

### Checklist

- [x] Update changelog in `CHANGELOG.md`.
- [x] Make sure `values.yaml` is valid.
