### PR TITLE
Add `items` schema for `.controlPlane.availabilityZones`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `items` schema for `.controlPlane.availabilityZones` in `values.schema.json`.
+
 ## [0.17.0] - 2022-11-07
 
 ### Changed

--- a/helm/cluster-openstack/values.schema.json
+++ b/helm/cluster-openstack/values.schema.json
@@ -69,6 +69,9 @@
             "type": "object",
             "properties": {
                 "availabilityZones": {
+                    "items": {
+                        "type": "string"
+                    },
                     "minItems": 1,
                     "type": "array"
                 },


### PR DESCRIPTION
This PR:

- Adds `items` schema for `.controlPlane.availabilityZones`.

This is required for proper validation and generating a data entry form for this app (towards https://github.com/giantswarm/roadmap/issues/1181)

### Testing

- [ ] Fresh install works.
- [ ] Upgrade from previous version works.

### Checklist

- [x] Update changelog in `CHANGELOG.md`.
- [ ] Make sure `values.yaml` is valid.
