### PR TITLE
make imageRepository configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Removed FeatureGates that default to true in Kubernetes 1.24.
+- A stanza in values file for customizing image repository of control-plane containers.
+- Bump up `cluster-shared` to 0.6.4
+
 ## [0.17.1] - 2023-02-20
 
 ### Added

--- a/helm/cluster-openstack/Chart.yaml
+++ b/helm/cluster-openstack/Chart.yaml
@@ -12,5 +12,5 @@ restrictions:
 icon: https://s.giantswarm.io/app-icons/openstack/1/light.svg
 dependencies:
   - name: cluster-shared
-    version: "0.6.3"
+    version: "0.6.4"
     repository: "https://giantswarm.github.io/cluster-catalog"

--- a/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
+++ b/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
@@ -24,6 +24,7 @@ spec:
                   After=containerd.service
     {{- end }}
     clusterConfiguration:
+      imageRepository: "registry.k8s.io"
       apiServer:
         certSANs:
           - 127.0.0.1

--- a/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
+++ b/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
@@ -24,7 +24,7 @@ spec:
                   After=containerd.service
     {{- end }}
     clusterConfiguration:
-      imageRepository: "registry.k8s.io"
+      imageRepository: "{{ .Values.controlPlane.imageRepository }}"
       apiServer:
         certSANs:
           - 127.0.0.1

--- a/helm/cluster-openstack/values.schema.json
+++ b/helm/cluster-openstack/values.schema.json
@@ -99,6 +99,9 @@
                 "image": {
                     "type": "string"
                 },
+                "imageRepository": {
+                    "type": "string"
+                },
                 "replicas": {
                     "minimum": 1,
                     "maximum": 7,

--- a/helm/cluster-openstack/values.yaml
+++ b/helm/cluster-openstack/values.yaml
@@ -1,13 +1,13 @@
 apiServer:
   enableAdmissionPlugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,PersistentVolumeClaimResize,DefaultStorageClass,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook"
-  featureGates: "TTLAfterFinished=true"
+  featureGates: ""
 baseDomain: ""  # Customer base domain, generally of the form "<customer codename>.gigantic.io".
 cloudConfig: ""  # Name of existing cloud-config secret in management cluster namespace.
 cloudName: ""  # Name of cloud in cloud-config secret "cloud.yaml" value.
 clusterDescription: ""  # Cluster description used in metadata.
 clusterName: ""  # Name of cluster. Used as base name for all cluster resources in the management cluster.
 controllerManager:
-  featureGates: "ExpandPersistentVolumes=true,TTLAfterFinished=true"
+  featureGates: ""
 dnsNameservers: []  # IPs of DNS nameservers to be used by the cluster machines (optional, will use OS defaults if not specified).
 kubernetesVersion: ""  # Version of Kubernetes. If machine images are specified, this will only be used for metadata.
 managementCluster: ""  # Name of cluster which owns this workload cluster.

--- a/helm/cluster-openstack/values.yaml
+++ b/helm/cluster-openstack/values.yaml
@@ -44,6 +44,7 @@ controlPlane:
   diskSize: 0  # Root volume disk size in GB. Ignored if bootFromVolume is false. Should be at least as large as the source image.
   flavor: ""  # Project-dependent flavor of control plane machines.
   image: ""  # Image name or root volume source UUID if bootFromVolume is true.
+  imageRepository: "registry.k8s.io"  # Image repository to pull control plane container images from.
   replicas: 0  # Number of replicas in control plane. Should be an odd number.
   bootFromVolume: false  # If true, machines will use a persistent root volume instead of an ephemeral volume.
   etcd:


### PR DESCRIPTION
This PR:

- Changes the imageRepository to `registry.k8s.io`
- Remove GA'd feature gates as Kubernetes v1.23 is EOL.

### Testing

- [x] Fresh install works.
- [x] Upgrade from previous version works.

### Checklist

- [x] Update changelog in `CHANGELOG.md`.
- [ ] Make sure `values.yaml` is valid.
